### PR TITLE
Fix hero asset references and add brand comparisons links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,19 +13,19 @@
   <meta name="robots" content="index,follow">
   <meta name="theme-color" content="#ffffff">
   <link rel="canonical" href="https://itstitanium.com/">
-  <link rel="preload" as="image" href="/assets/img/itstitaniun-hero-pans-1600.webp" imagesrcset="/assets/img/itstitaniun-hero-pans-800.webp 800w, /assets/img/itstitaniun-hero-pans-1200.webp 1200w, /assets/img/itstitaniun-hero-pans-1600.webp 1600w" imagesizes="(min-width: 768px) 60vw, 100vw">
+  <link rel="preload" as="image" href="/assets/img/itstitanium-hero-pans-1600.webp" imagesrcset="/assets/img/itstitanium-hero-pans-800.webp 800w, /assets/img/itstitanium-hero-pans-1200.webp 1200w, /assets/img/itstitanium-hero-pans-1600.webp 1600w" imagesizes="(min-width: 768px) 60vw, 100vw">
   <link rel="stylesheet" href="/base.css">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="It’s Titanium">
   <meta property="og:title" content="Titanium Cookware Buying Guide 2025 | It’s Titanium">
   <meta property="og:description" content="Trusted 2025 titanium cookware guide with lab testing notes, quick answers, care advice, and vetted picks for home cooks upgrading pans.">
   <meta property="og:url" content="https://itstitanium.com/">
-    <meta property="og:image" content="https://itstitanium.com/assets/img/itstitaniun-hero-pans-1600.webp">
+    <meta property="og:image" content="https://itstitanium.com/assets/img/itstitanium-hero-pans-1600.webp">
     <meta property="og:image:alt" content="Titanium cookware hero image">
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:title" content="Titanium Cookware Buying Guide 2025 | It’s Titanium">
     <meta property="twitter:description" content="Trusted 2025 titanium cookware guide with lab testing notes, quick answers, care advice, and vetted picks for home cooks upgrading pans.">
-    <meta property="twitter:image" content="https://itstitanium.com/assets/img/itstitaniun-hero-pans-1600.webp">
+    <meta property="twitter:image" content="https://itstitanium.com/assets/img/itstitanium-hero-pans-1600.webp">
     <meta property="twitter:image:alt" content="Titanium cookware hero image">
   <script type="application/ld+json">
 {
@@ -85,8 +85,8 @@
     {
       "@type": "ImageObject",
       "@id": "https://itstitanium.com/#primaryimage",
-      "url": "https://itstitanium.com/assets/img/itstitaniun-hero-pans-1600.webp",
-      "contentUrl": "https://itstitanium.com/assets/img/itstitaniun-hero-pans-1600.webp",
+      "url": "https://itstitanium.com/assets/img/itstitanium-hero-pans-1600.webp",
+      "contentUrl": "https://itstitanium.com/assets/img/itstitanium-hero-pans-1600.webp",
       "caption": "Stack of titanium frying pans on a gas stove",
       "width": "1600",
       "height": "900"
@@ -199,6 +199,7 @@
         <a href="/best-titanium-pans-2025/">Best pans</a>
         <a href="/titanium-cookware-guide/">Buying guide</a>
         <a href="/care-and-cleaning/">Care & cleaning</a>
+        <a href="/brand-comparisons/">Brand comparisons</a>
         <a href="/blog/">Research</a>
       </nav>
       <form class="header-search" role="search" action="/search.html">
@@ -234,7 +235,7 @@
               <a class="btn btn-secondary" href="/titanium-vs-ceramic/">Compare with ceramic</a>
             </div>
             <figure class="hero-media">
-              <img src="/assets/img/itstitaniun-hero-pans-1600.webp" alt="Stack of titanium frying pans on a gas stove" width="1600" height="900" loading="eager" decoding="async">
+              <img src="/assets/img/itstitanium-hero-pans-1600.webp" alt="Stack of titanium frying pans on a gas stove" width="1600" height="900" loading="eager" decoding="async">
               <figcaption>Our 2025 testing cycle covers heat distribution, release, durability, and cleaning time.</figcaption>
             </figure>
           </section>
@@ -378,12 +379,16 @@
                 <p>See test data and durability notes for our current picks.</p>
               </article>
               <article class="card">
-                <h3><a href="/titanium-cookware-guide/">Titanium vs stainless steel</a></h3>
+                <h3><a href="/titanium-vs-ceramic/">Titanium vs ceramic</a></h3>
                 <p>Compare heat profiles and weight before you buy.</p>
               </article>
               <article class="card">
                 <h3><a href="/care-and-cleaning/">Care and cleaning checklist</a></h3>
                 <p>Step-by-step maintenance for longer lasting coatings.</p>
+              </article>
+              <article class="card">
+                <h3><a href="/brand-comparisons/">Brand comparisons</a></h3>
+                <p>How T-fal, Hestan, Scanpan and others differ in build and warranty.</p>
               </article>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- correct the hero image preload, social tags, and schema references to use the properly spelled filename
- update the hero image markup and navigation to reference the brand comparisons page
- refresh related guides to point to the titanium vs ceramic article and include a brand comparisons card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d16da115888329bc2171d1e72f78c5