### PR TITLE
Add disclosure blocks above hero sections

### DIFF
--- a/public/best-titanium-pans-2025/index.html
+++ b/public/best-titanium-pans-2025/index.html
@@ -227,6 +227,9 @@
     </div>
   </header>
   <main id="content">
+    <section class="disclosure" id="disclosure">
+      <p>We test and recommend cookware. If you purchase through links on this site, we may earn a commission at no cost to you. Our reviews are independent and based on measurable factors like build, materials, usability, and care requirements.</p>
+    </section>
     <article class="wrap">
       <section class="hero">
         <h1>Best Titanium Pans for 2025</h1>

--- a/public/brand-comparisons/index.html
+++ b/public/brand-comparisons/index.html
@@ -213,6 +213,9 @@
     </div>
   </header>
   <main id="content">
+    <section class="disclosure" id="disclosure">
+      <p>We test and recommend cookware. If you purchase through links on this site, we may earn a commission at no cost to you. Our reviews are independent and based on measurable factors like build, materials, usability, and care requirements.</p>
+    </section>
     <article class="wrap">
       <section class="hero">
         <h1>Titanium Cookware Brand Comparisons</h1>

--- a/public/care-and-cleaning/index.html
+++ b/public/care-and-cleaning/index.html
@@ -212,6 +212,9 @@
     </div>
   </header>
   <main id="content">
+    <section class="disclosure" id="disclosure">
+      <p>We test and recommend cookware. If you purchase through links on this site, we may earn a commission at no cost to you. Our reviews are independent and based on measurable factors like build, materials, usability, and care requirements.</p>
+    </section>
     <article class="wrap">
       <section class="hero">
         <h1>Titanium Pan Care and Cleaning Checklist</h1>

--- a/public/titanium-cookware-guide/index.html
+++ b/public/titanium-cookware-guide/index.html
@@ -224,6 +224,9 @@
     </div>
   </header>
   <main id="content">
+    <section class="disclosure" id="disclosure">
+      <p>We test and recommend cookware. If you purchase through links on this site, we may earn a commission at no cost to you. Our reviews are independent and based on measurable factors like build, materials, usability, and care requirements.</p>
+    </section>
     <article class="wrap">
       <section class="hero">
         <h1>2025 Titanium Cookware Guide</h1>

--- a/public/titanium-vs-ceramic/index.html
+++ b/public/titanium-vs-ceramic/index.html
@@ -221,6 +221,9 @@
     </div>
   </header>
   <main id="content">
+    <section class="disclosure" id="disclosure">
+      <p>We test and recommend cookware. If you purchase through links on this site, we may earn a commission at no cost to you. Our reviews are independent and based on measurable factors like build, materials, usability, and care requirements.</p>
+    </section>
     <article class="wrap">
       <section class="hero">
         <h1>Titanium vs Ceramic Cookware</h1>


### PR DESCRIPTION
## Summary
- add the reusable disclosure section immediately after `<main id="content">` on the titanium cookware article templates
- ensure the disclosure appears before each hero so it renders above the fold on all updated pages

## Testing
- `npm run report`


------
https://chatgpt.com/codex/tasks/task_e_68d40e34cefc8329bf0ef95af1d7564b