### PR TITLE
Align FAQ sections with canonical bank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "itstitanium",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "itstitanium",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/public/best-titanium-pans-2025/index.html
+++ b/public/best-titanium-pans-2025/index.html
@@ -287,11 +287,12 @@
         </ul>
       </section>
 
-      <section id="faq" class="faq">
+      <section id="faqs" class="faq">
         <h2>FAQ</h2>
-        <details><summary>Which titanium skillet lasted longest in 2025 abrasion tests?</summary><div>All-Clad FusionTec kept 97 percent of its release after 2,000 non scratch pad cycles, matching the manufacturer claim that we verified during lab retesting.</div></details>
-        <details><summary>Do titanium pans work on induction cooktops?</summary><div>Check for a magnetic base or bonded steel plate. FusionTec and Scanpan HaptIQ worked on Bosch and GE induction ranges in our kitchen lab.</div></details>
-        <details><summary>What price range covers a reliable titanium set?</summary><div>Budget for 150 to 250 USD for a two pan bundle. Holiday deals can dip value picks toward 120 USD, but warranty support often drops with no name sellers.</div></details>
+        <details><summary>Is titanium cookware safe for high-heat searing?</summary><div>Most consumer ‘titanium’ pans are aluminum with titanium-reinforced nonstick. Use medium heat for longevity and follow the manufacturer’s guidance for searing.</div></details>
+        <details><summary>How do I clean a titanium-reinforced nonstick pan?</summary><div>Let it cool, hand-wash with mild soap and a soft sponge, and avoid abrasive pads. Dry fully to protect the surface.</div></details>
+        <details><summary>Is it dishwasher safe?</summary><div>Many pans are labeled dishwasher safe, but hand-washing helps preserve coatings and handles. Check the specific model’s manual.</div></details>
+        <details><summary>Will it work on induction?</summary><div>Only pans with a magnetic base are induction compatible. A magnet test on the base can confirm.</div></details>
       </section>
 
       <section class="next-steps">

--- a/public/brand-comparisons/index.html
+++ b/public/brand-comparisons/index.html
@@ -264,11 +264,12 @@
         </ul>
       </section>
 
-      <section id="faq" class="faq">
+      <section id="faqs" class="faq">
         <h2>FAQ</h2>
-        <details><summary>Which titanium cookware brand has the best warranty?</summary><div>All-Clad offers lifetime coverage on the base with multi year coating support when you follow care instructions, while most value brands offer two year plans.</div></details>
-        <details><summary>Do budget titanium pans match premium heat performance?</summary><div>Budget pans like T-fal Ultimate stay within 18°F variance, yet premium lines sit closer to 12°F, so searing is more predictable with higher end sets.</div></details>
-        <details><summary>Which brand is best for induction cooktops?</summary><div>All-Clad FusionTec and Scanpan HaptIQ have full magnetic bases. Ninja models vary by SKU, so confirm packaging details.</div></details>
+        <details><summary>Is titanium cookware safe for high-heat searing?</summary><div>Most consumer ‘titanium’ pans are aluminum with titanium-reinforced nonstick. Use medium heat for longevity and follow the manufacturer’s guidance for searing.</div></details>
+        <details><summary>How do I clean a titanium-reinforced nonstick pan?</summary><div>Let it cool, hand-wash with mild soap and a soft sponge, and avoid abrasive pads. Dry fully to protect the surface.</div></details>
+        <details><summary>Is it dishwasher safe?</summary><div>Many pans are labeled dishwasher safe, but hand-washing helps preserve coatings and handles. Check the specific model’s manual.</div></details>
+        <details><summary>Will it work on induction?</summary><div>Only pans with a magnetic base are induction compatible. A magnet test on the base can confirm.</div></details>
       </section>
 
       <section class="next-steps">

--- a/public/care-and-cleaning/index.html
+++ b/public/care-and-cleaning/index.html
@@ -261,11 +261,12 @@
         </ul>
       </section>
 
-      <section id="faq" class="faq">
+      <section id="faqs" class="faq">
         <h2>FAQ</h2>
-        <details><summary>Can titanium cookware go in the dishwasher?</summary><div>Hand washing keeps coatings resilient. Dishwashers can shorten coating life, so reserve them for emergencies only.</div></details>
-        <details><summary>What cleaners are safe for titanium reinforced pans?</summary><div>Use mild soap, warm water, baking soda paste, and nylon or silicone tools. Skip abrasive powders and never use steel wool.</div></details>
-        <details><summary>How often should I reseason a titanium pan?</summary><div>Refresh the surface with a teaspoon of neutral oil every few weeks, heating it gently for one minute before wiping dry.</div></details>
+        <details><summary>Is titanium cookware safe for high-heat searing?</summary><div>Most consumer ‘titanium’ pans are aluminum with titanium-reinforced nonstick. Use medium heat for longevity and follow the manufacturer’s guidance for searing.</div></details>
+        <details><summary>How do I clean a titanium-reinforced nonstick pan?</summary><div>Let it cool, hand-wash with mild soap and a soft sponge, and avoid abrasive pads. Dry fully to protect the surface.</div></details>
+        <details><summary>Is it dishwasher safe?</summary><div>Many pans are labeled dishwasher safe, but hand-washing helps preserve coatings and handles. Check the specific model’s manual.</div></details>
+        <details><summary>Will it work on induction?</summary><div>Only pans with a magnetic base are induction compatible. A magnet test on the base can confirm.</div></details>
       </section>
 
       <section class="next-steps">

--- a/public/titanium-cookware-guide/index.html
+++ b/public/titanium-cookware-guide/index.html
@@ -272,11 +272,12 @@
         </ul>
       </section>
 
-      <section id="faq" class="faq">
+      <section id="faqs" class="faq">
         <h2>FAQ</h2>
-        <details><summary>What makes titanium reinforced cookware different from solid titanium?</summary><div>Consumer models rely on titanium particles within PTFE or ceramic blends layered over aluminum or stainless bodies. Solid titanium is rare because it spreads heat slowly and costs far more, as outlined by the Cookware Manufacturers Association.</div></details>
-        <details><summary>Is titanium cookware safe for daily use?</summary><div>Yes when you cook below 500°F, ventilate your kitchen, and avoid scratched coatings, aligning with FDA commentary on PTFE safety.</div></details>
-        <details><summary>How long should titanium pans last?</summary><div>Expect three to five years of steady use with proper care. Our reader survey showed average replacement at 4.3 years when owners avoided metal tools and dishwashers.</div></details>
+        <details><summary>Is titanium cookware safe for high-heat searing?</summary><div>Most consumer ‘titanium’ pans are aluminum with titanium-reinforced nonstick. Use medium heat for longevity and follow the manufacturer’s guidance for searing.</div></details>
+        <details><summary>How do I clean a titanium-reinforced nonstick pan?</summary><div>Let it cool, hand-wash with mild soap and a soft sponge, and avoid abrasive pads. Dry fully to protect the surface.</div></details>
+        <details><summary>Is it dishwasher safe?</summary><div>Many pans are labeled dishwasher safe, but hand-washing helps preserve coatings and handles. Check the specific model’s manual.</div></details>
+        <details><summary>Will it work on induction?</summary><div>Only pans with a magnetic base are induction compatible. A magnet test on the base can confirm.</div></details>
       </section>
 
       <section class="next-steps">

--- a/public/titanium-vs-ceramic/index.html
+++ b/public/titanium-vs-ceramic/index.html
@@ -269,11 +269,12 @@
         </ul>
       </section>
 
-      <section id="faq" class="faq">
+      <section id="faqs" class="faq">
         <h2>FAQ</h2>
-        <details><summary>Which coating lasts longer, titanium reinforced or ceramic?</summary><div>Titanium reinforced PTFE blends held their release for three to five years in our testing, while ceramic coatings dropped to 70 range scores after a year of daily use.</div></details>
-        <details><summary>Can ceramic pans handle higher heat than titanium?</summary><div>Ceramic tolerates short bursts around 600°F but loses slickness faster when overheated, so we still prefer titanium for everyday sautéing.</div></details>
-        <details><summary>Which cookware is safer for metal utensils?</summary><div>Use silicone or wood tools on both coatings. Titanium reinforcement shrugs off light contact but sharp metal edges will still scar the surface.</div></details>
+        <details><summary>Is titanium cookware safe for high-heat searing?</summary><div>Most consumer ‘titanium’ pans are aluminum with titanium-reinforced nonstick. Use medium heat for longevity and follow the manufacturer’s guidance for searing.</div></details>
+        <details><summary>How do I clean a titanium-reinforced nonstick pan?</summary><div>Let it cool, hand-wash with mild soap and a soft sponge, and avoid abrasive pads. Dry fully to protect the surface.</div></details>
+        <details><summary>Is it dishwasher safe?</summary><div>Many pans are labeled dishwasher safe, but hand-washing helps preserve coatings and handles. Check the specific model’s manual.</div></details>
+        <details><summary>Will it work on induction?</summary><div>Only pans with a magnetic base are induction compatible. A magnet test on the base can confirm.</div></details>
       </section>
 
       <section class="next-steps">


### PR DESCRIPTION
## Summary
- switch FAQ sections on key titanium guides to use the standardized `faqs` identifier
- replace legacy questions with the four canonical entries from the shared FAQ bank across all affected pages
- refresh lockfile from the current npm toolchain to support report checks

## Testing
- npm run report

------
https://chatgpt.com/codex/tasks/task_e_68d40e389cf083299ea88b9173d78251