### PR TITLE
Fix homepage image assets and metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,16 +16,18 @@
   <meta property="og:description" content="Compare top titanium cookware picks, understand coatings vs pure titanium, and learn how to care for your pan. Updated for 2025.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://itstitaniun.com/">
-  <meta property="og:image" content="/assets/img/hero-laydown-1200.webp">
+  <meta property="og:image" content="/assets/img/itstitanium-hero-pans-1200.webp">
   <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
+  <meta property="og:image:height" content="900">
+  <meta property="og:image:alt" content="Two pans simmering on a black induction cooktop with soft steam">
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Titanium Cookware: Best Pans, Care & Buying Guide (2025)">
   <meta name="twitter:description" content="Buyer-first reviews and care tips for titanium cookware.">
-  <meta name="twitter:image" content="/assets/img/hero-laydown-1200.webp">
+  <meta name="twitter:image" content="/assets/img/itstitanium-hero-pans-1200.webp">
+  <meta name="twitter:image:alt" content="Two pans simmering on a black induction cooktop with soft steam">
   <!-- Preload hero -->
-  <link rel="preload" as="image" href="/assets/img/hero-laydown-1600.webp" imagesrcset="/assets/img/hero-laydown-800.webp 800w, /assets/img/hero-laydown-1200.webp 1200w, /assets/img/hero-laydown-1600.webp 1600w" imagesizes="(max-width: 1100px) 100vw, 1100px">
+  <link rel="preload" as="image" href="/assets/img/itstitanium-hero-pans-1600.webp" imagesrcset="/assets/img/itstitanium-hero-pans-800.webp 800w, /assets/img/itstitanium-hero-pans-1200.webp 1200w, /assets/img/itstitanium-hero-pans-1600.webp 1600w" imagesizes="(max-width: 1100px) 100vw, 1100px">
   <!-- CSS -->
   <link rel="stylesheet" href="/styles/main.css">
   <link rel="stylesheet" href="/styles/base.css">
@@ -72,9 +74,9 @@
         "url": "https://itstitaniun.com/",
         "logo": {
           "@type": "ImageObject",
-          "url": "https://itstitaniun.com/assets/img/logo-512.png",
-          "width": 512,
-          "height": 512
+          "url": "https://itstitaniun.com/assets/img/itstitaniun-handle-detail-1200.webp",
+          "width": 1200,
+          "height": 1200
         },
         "sameAs": [
           "https://www.youtube.com/@itstitaniun",
@@ -115,9 +117,10 @@
         "inLanguage": "en",
         "primaryImageOfPage": {
           "@type": "ImageObject",
-          "url": "https://itstitaniun.com/assets/img/hero-laydown-1200.webp",
+          "url": "https://itstitaniun.com/assets/img/itstitanium-hero-pans-1200.webp",
           "width": 1200,
-          "height": 630
+          "height": 900,
+          "caption": "Two pans simmering on a black induction cooktop with soft steam"
         },
         "genre": "Cookware",
         "learningResourceType": "Buying guide",
@@ -171,7 +174,7 @@
         <a class="btn btn-primary" href="/best-titanium-pans-2025/">See Best Titanium Pans 2025</a>
       </div>
       <figure class="hero-media">
-        <img src="/assets/img/hero-laydown-1600.webp" width="1600" height="1067" alt="Titanium and titanium-reinforced pans laid out with utensils" decoding="async">
+        <img src="/assets/img/itstitanium-hero-pans-1600.webp" width="1600" height="900" alt="Two pans simmering on a black induction cooktop with soft steam" decoding="async">
         <figcaption class="sr-only">Top-down layout of titanium cookware styles.</figcaption>
       </figure>
     </section>
@@ -277,7 +280,7 @@
       <div class="card-grid grid-3">
         <article class="card product-card">
           <figure>
-            <img src="/assets/img/top-picks-900.webp" width="900" height="506" alt="Assortment of recommended titanium-reinforced skillets" loading="lazy" decoding="async">
+            <img src="/assets/img/itstitaniun-even-browning-1200.webp" width="1200" height="800" alt="Overhead pancake showing even browning across the pan surface" loading="lazy" decoding="async">
             <figcaption>Editor’s Choice short list for everyday cooking.</figcaption>
           </figure>
           <h3>Top Picks for 2025</h3>
@@ -287,7 +290,7 @@
 
         <article class="card">
           <figure>
-            <img src="/assets/img/titanium-vs-ceramic-900.webp" width="900" height="506" alt="Side-by-side titanium and ceramic pans" loading="lazy" decoding="async">
+            <img src="/assets/img/itstitaniun-rim-comparison-1200.webp" width="1200" height="900" alt="Macro of two pan rims showing material differences" loading="lazy" decoding="async">
             <figcaption>Quick comparison of surface, heat, and care.</figcaption>
           </figure>
           <h3>Titanium vs Ceramic</h3>
@@ -297,7 +300,7 @@
 
         <article class="card">
           <figure>
-            <img src="/assets/img/care-cleaning-900.webp" width="900" height="506" alt="Hand washing a skillet with a soft sponge" loading="lazy" decoding="async">
+            <img src="/assets/img/itstitaniun-care-cleaning-1400.webp" width="1400" height="788" alt="Stacked nonstick pans stored with protectors in a cabinet" loading="lazy" decoding="async">
             <figcaption>Care that keeps the surface slick and safe.</figcaption>
           </figure>
           <h3>Care & Cleaning</h3>


### PR DESCRIPTION
## Summary
- replace the homepage hero and start-here card imagery with available assets in `/public/assets/img`
- update Open Graph, Twitter, and preload references to the new hero artwork and alt text
- point the JSON-LD logo and primary image to the new files so metadata stays in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d43fe027b08329b129b347c875fec7