### PR TITLE
Fix broken hero image on titanium cookware guide

### DIFF
--- a/public/titanium-cookware-guide/index.html
+++ b/public/titanium-cookware-guide/index.html
@@ -13,20 +13,20 @@
 <link rel="canonical" href="https://itstitaniun.com/titanium-cookware-guide/">
 <meta name="theme-color" content="#ffffff">
 <link rel="manifest" href="/manifest.json">
-<link rel="preload" as="image" href="/assets/img/hero/guide-hero-1400.avif" imagesrcset="/assets/img/hero/guide-hero-1400.avif 1400w, /assets/img/hero/guide-hero-900.avif 900w, /assets/img/hero/guide-hero-600.avif 600w" imagesizes="(min-width:960px) 900px, 100vw">
+<link rel="preload" as="image" href="/assets/img/itstitanium-hero-pans-1600.webp" imagesrcset="/assets/img/itstitanium-hero-pans-800.webp 800w, /assets/img/itstitanium-hero-pans-1200.webp 1200w, /assets/img/itstitanium-hero-pans-1600.webp 1600w" imagesizes="(min-width:960px) 900px, 100vw">
 <link rel="stylesheet" href="/base.css">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="It’s Titanium">
 <meta property="og:title" content="Titanium Cookware Guide 2025: Construction, Safety, Care">
 <meta property="og:description" content="An evergreen buying guide to titanium cookware: construction, what specs matter, induction and oven rules, plus care routines that extend coating life.">
 <meta property="og:url" content="https://itstitaniun.com/titanium-cookware-guide/">
-<meta property="og:image" content="https://itstitaniun.com/assets/img/hero/guide-hero-1400.webp">
-<meta property="og:image:alt" content="Titanium cookware set arranged on a kitchen counter">
+<meta property="og:image" content="https://itstitaniun.com/assets/img/itstitanium-hero-pans-1600.webp">
+<meta property="og:image:alt" content="Titanium skillets and saucepans arranged on a light kitchen counter">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Titanium Cookware Guide 2025: Construction, Safety, Care">
 <meta name="twitter:description" content="Understand materials and specs, then learn the care routine that keeps titanium-reinforced nonstick slick for years.">
-<meta name="twitter:image" content="https://itstitaniun.com/assets/img/hero/guide-hero-1400.webp">
-<meta name="twitter:image:alt" content="Titanium cookware hero image">
+<meta name="twitter:image" content="https://itstitaniun.com/assets/img/itstitanium-hero-pans-1600.webp">
+<meta name="twitter:image:alt" content="Titanium skillets and saucepans arranged on a light kitchen counter">
 <!-- freshness signals -->
 <meta name="dateModified" content="2025-09-25">
 <!-- small critical CSS kept -->
@@ -66,7 +66,7 @@
     {"@type":"WebSite","@id":"https://itstitaniun.com/#website","url":"https://itstitaniun.com/","name":"It’s Titanium","inLanguage":"en-US","publisher":{"@id":"https://itstitaniun.com/#org"},"potentialAction":{"@type":"SearchAction","target":"https://itstitaniun.com/search.html?q={search_term_string}","query-input":"required name=search_term_string"}},
     {"@type":"BreadcrumbList","@id":"https://itstitaniun.com/titanium-cookware-guide/#breadcrumbs","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://itstitaniun.com/"},{"@type":"ListItem","position":2,"name":"Titanium Cookware Guide","item":"https://itstitaniun.com/titanium-cookware-guide/"}]},
     {"@type":"WebPage","@id":"https://itstitaniun.com/titanium-cookware-guide/#webpage","url":"https://itstitaniun.com/titanium-cookware-guide/","isPartOf":{"@id":"https://itstitaniun.com/#website"},"breadcrumb":{"@id":"https://itstitaniun.com/titanium-cookware-guide/#breadcrumbs"},"name":"Titanium Cookware Guide 2025: Construction, Safety, Care","inLanguage":"en-US","description":"Buying guide to titanium cookware: construction, which specs matter, induction/oven-safe rules, and care routines to extend coating life.","datePublished":"2025-09-20","dateModified":"2025-09-25"},
-    {"@type":"ImageObject","@id":"https://itstitaniun.com/titanium-cookware-guide/#primaryimage","url":"https://itstitaniun.com/assets/img/hero/guide-hero-1400.webp","contentUrl":"https://itstitaniun.com/assets/img/hero/guide-hero-1400.webp","caption":"Titanium cookware set arranged on a kitchen counter","width":1400,"height":933},
+    {"@type":"ImageObject","@id":"https://itstitaniun.com/titanium-cookware-guide/#primaryimage","url":"https://itstitaniun.com/assets/img/itstitanium-hero-pans-1600.webp","contentUrl":"https://itstitaniun.com/assets/img/itstitanium-hero-pans-1600.webp","caption":"Titanium skillets and saucepans arranged on a light kitchen counter","width":1600,"height":1067},
     {"@type":"BlogPosting","@id":"https://itstitaniun.com/titanium-cookware-guide/#blog","headline":"Titanium Cookware Guide 2025: Construction, Safety, Care","description":"Understand materials and specs, then learn the care routine that keeps titanium-reinforced nonstick slick for years.","datePublished":"2025-09-20","dateModified":"2025-09-25","inLanguage":"en-US","mainEntityOfPage":{"@id":"https://itstitaniun.com/titanium-cookware-guide/#webpage"},"author":{"@id":"https://itstitaniun.com/#org","@type":"Organization","name":"It’s Titanium"},"publisher":{"@id":"https://itstitaniun.com/#org"},"image":{"@id":"https://itstitaniun.com/titanium-cookware-guide/#primaryimage"}},
     {"@type":"FAQPage","@id":"https://itstitaniun.com/titanium-cookware-guide/#faq","mainEntity":[{"@type":"Question","name":"Is titanium cookware the same as titanium-reinforced nonstick?","acceptedAnswer":{"@type":"Answer","text":"Not exactly. Pure titanium pans are uncommon outside backpacking gear. Many consumer “titanium” pans are aluminum with a titanium-reinforced nonstick coating for durability."}},{"@type":"Question","name":"Is titanium cookware safe for high-heat searing?","acceptedAnswer":{"@type":"Answer","text":"Most consumer 'titanium' pans are aluminum with titanium-reinforced nonstick. Use medium heat for longevity and follow the manufacturer’s guidance for searing."}},{"@type":"Question","name":"How do I clean a titanium-reinforced nonstick pan?","acceptedAnswer":{"@type":"Answer","text":"Let it cool, hand-wash with mild soap and a soft sponge, and avoid abrasive pads. Dry fully to protect the surface."}},{"@type":"Question","name":"Will it work on induction?","acceptedAnswer":{"@type":"Answer","text":"Only pans with a magnetic base are induction compatible. A magnet test on the base can confirm."}},{"@type":"Question","name":"Is it dishwasher safe?","acceptedAnswer":{"@type":"Answer","text":"Many pans are labeled dishwasher safe, but hand-washing helps preserve coatings and handles. Check the specific model’s manual."}}]},
     {"@type":"HowTo","@id":"https://itstitaniun.com/titanium-cookware-guide/#howto","name":"How to evaluate a titanium pan in-store","step":[{"@type":"HowToStep","position":1,"name":"Verify construction","text":"Look for aluminum or stainless body with titanium-reinforced PTFE or ceramic coating; confirm printed oven-safe rating."},{"@type":"HowToStep","position":2,"name":"Check balance and weight","text":"A 10-inch skillet typically ranges ~1.6–2.6 lb; choose what feels steady in-hand without wrist strain."},{"@type":"HowToStep","position":3,"name":"Confirm induction","text":"Use a small magnet on the base; it should stick firmly for induction compatibility."}]},
@@ -108,7 +108,7 @@
     <div class="card" style="display:flex;gap:12px;align-items:center;flex-wrap:wrap">
       <strong style="margin-right:6px">Share:</strong>
       <a class="btn btn-secondary" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fitstitaniun.com%2Ftitanium-cookware-guide%2F" rel="noopener" target="_blank" aria-label="Share on LinkedIn">LinkedIn</a>
-      <a class="btn btn-secondary" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fitstitaniun.com%2Ftitanium-cookware-guide%2F&media=https%3A%2F%2Fitstitaniun.com%2Fassets%2Fimg%2Fhero%2Fguide-hero-1400.webp&description=Titanium%20Cookware%20Guide%202025" rel="noopener" target="_blank" aria-label="Share on Pinterest">Pinterest</a>
+      <a class="btn btn-secondary" href="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fitstitaniun.com%2Ftitanium-cookware-guide%2F&media=https%3A%2F%2Fitstitaniun.com%2Fassets%2Fimg%2Fitstitanium-hero-pans-1600.webp&description=Titanium%20Cookware%20Guide%202025" rel="noopener" target="_blank" aria-label="Share on Pinterest">Pinterest</a>
       <a class="btn btn-secondary" href="https://api.whatsapp.com/send?text=Titanium%20Cookware%20Guide%202025%20%E2%80%94%20https%3A%2F%2Fitstitaniun.com%2Ftitanium-cookware-guide%2F" rel="noopener" target="_blank" aria-label="Share on WhatsApp">WhatsApp</a>
     </div>
   </section>
@@ -128,9 +128,8 @@
   </div>
   <figure>
   <picture>
-    <source type="image/avif" srcset="/assets/img/hero/guide-hero-1400.avif 1400w, /assets/img/hero/guide-hero-900.avif 900w, /assets/img/hero/guide-hero-600.avif 600w" sizes="(min-width:960px) 900px, 100vw">
-    <source type="image/webp" srcset="/assets/img/hero/guide-hero-1400.webp 1400w, /assets/img/hero/guide-hero-900.webp 900w, /assets/img/hero/guide-hero-600.webp 600w" sizes="(min-width:960px) 900px, 100vw">
-    <img src="/assets/img/hero/guide-hero-1400.jpg" alt="Titanium cookware set arranged on a kitchen counter" width="1400" height="933" loading="eager" decoding="async">
+    <source type="image/webp" srcset="/assets/img/itstitanium-hero-pans-1600.webp 1600w, /assets/img/itstitanium-hero-pans-1200.webp 1200w, /assets/img/itstitanium-hero-pans-800.webp 800w" sizes="(min-width:960px) 900px, 100vw">
+    <img src="/assets/img/itstitanium-hero-pans-1200.webp" alt="Titanium skillets and saucepans arranged on a light kitchen counter" width="1600" height="1067" loading="eager" decoding="async">
   </picture>
   <figcaption class="steel">Representative cookware layout. Always verify model-specific specs with the manufacturer.</figcaption>
 </figure>


### PR DESCRIPTION
## Summary
- point hero image preload and social metadata to the existing itstitanium hero pans artwork
- update the picture element and Pinterest share link so the guide displays the correct cookware image

## Testing
- npm run report

------
https://chatgpt.com/codex/tasks/task_e_68d5c33f75408329b67e171b8f6484d0