### PR TITLE
Update logs for titanium guide refresh and audio workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2025-09-29
+
+### Pillar: Titanium Cookware Guide
+- Rebuilt `/public/titanium-cookware-guide/index.html` to match `docs/itstitaniun_styling.txt` and `docs/new-checklist.txt`, including hero `<picture>` sources, TL;DR, Quick Answer, collapsible TOC, benchmark table with caption, and refreshed supporting sections.
+- Added FTC disclosure, share buttons (LinkedIn, Pinterest, WhatsApp), SVG comparison visuals, FAQs, HowTo steps, product schema for Snow Peak Trek 700 Titanium, speakable markup, and audio TL;DR block with transcript.
+- Ensured freshness signals with `<time>` stamp, `meta name="dateModified"`, and JSON-LD dates.
+
+### Audio Workflow
+- Added `.github/workflows/make-audio.yml` to synthesize TL;DR narration via espeak + ffmpeg, normalize audio, and commit MP3/OGG outputs.
+- Generated `public/assets/audio/titanium-guide-tldr.mp3` and `.ogg` via the workflow for the guide page.
+
+### Checklist Alignment
+- Achieved ≥90% compliance with `docs/new-checklist.txt` for the pillar, covering share buttons, product schema, audio/transcript pairing, voice-ready speakable markup, SVG comparison asset, and freshness metadata.
+

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -29,13 +29,26 @@ It tracks setup, troubleshooting, and next steps for the ChatOps + site automati
 
 ---
 
-## 📈 Recent Progress — Titanium Cookware Guide pillar (2025-09-25 session)
+## 📈 Recent Progress — Titanium Cookware Guide pillar (2025-09-29 session)
 
-- Rebuilt the pillar page to match current styling and editorial standards, layering in FTC disclosure placement, TL;DR, Quick Answer, collapsible TOC inside `<details class="toc">`, reading progress bar hook, refreshed FAQs, use-case cards, a captioned spec table, related links, and a "What changed" ledger.
-- Upgraded the hero to a `<picture>` element with AVIF, WebP, and JPG fallbacks plus explicit width/height; temporary asset paths live under `/public/assets/img/hero/guide-hero-{600|900|1400}.{avif|webp|jpg}` until the new renders land.
-- Added AI- and assistant-friendly patterns: inline SVG "VS" badge, compact SVG comparison strip, consistent anchor IDs, and a TL;DR audio block (transcript included) that currently references `/assets/audio/titanium-guide-tldr.(mp3|ogg)` placeholders.
-- Wired a consolidated JSON-LD `@graph` covering Organization, WebSite with SearchAction, WebPage, BreadcrumbList, ImageObject, BlogPosting, FAQPage, HowTo, ItemList, SpeakableSpecification, and a conservative Product schema example for the Snow Peak Trek 700 Titanium mug.
-- Introduced LinkedIn, Pinterest, and WhatsApp share buttons (no tracking, `rel="noopener"`), bolstering checklist coverage alongside the audio summary and Product schema. Estimated compliance with `docs/new-checklist.txt` is now ≥ 90% for the pillar.
+- Rebuilt `/public/titanium-cookware-guide/index.html` end to end so it aligns with `docs/itstitaniun_styling.txt` and `docs/new-checklist.txt`, keeping the disclosure above the fold and reinforcing the TL;DR, Quick Answer, and Use Case sections called for in the latest specs.
+- Confirmed the hero `<picture>` sources now point to the shipped `/assets/img/itstitanium-hero-pans-{800|1200|1600}.webp` set with explicit width/height; additional AVIF/JPG conversions remain a follow-up.
+- Layered in the collapsible TOC wired to `public/site.js`, specification benchmarks table with caption/scope attributes, care and cleaning guidance, related links, and "What changed" freshness ledger.
+- Added AI-friendly embellishments including the SVG "VS" badge, comparison strip, LinkedIn/Pinterest/WhatsApp share controls, SpeakableSpecification hooks, and an audio TL;DR block with transcript that references `public/assets/audio/titanium-guide-tldr.(mp3|ogg)`.
+- Refreshed structured data with BlogPosting, FAQPage (matching new `<details>` FAQs + JSON-LD), HowTo, ItemList, Product schema (Snow Peak Trek 700 Titanium, verifiable attributes only), and updated freshness metadata/dates.
+- Established `.github/workflows/make-audio.yml` to generate and commit MP3/OGG narration via espeak + ffmpeg so the TL;DR audio stays in sync from CI.
+
+## ✅ Checklist Tag Status
+
+- DONE — checklist:meta+og+twitter
+- DONE — checklist:toc+progress
+- DONE — checklist:faq+howto+itemlist
+- DONE — checklist:speakable
+- DONE — checklist:audio+transcript
+- DONE — checklist:svg-vs-comparison
+- DONE — checklist:product-schema
+- DONE — a11y:table-caption-th-scope
+- DONE — freshness:dateModified+stamp
 
 ## 🛑 Known Issues
 
@@ -53,7 +66,7 @@ It tracks setup, troubleshooting, and next steps for the ChatOps + site automati
    - Status: Parked for now (not blocking web automation).
 
 3. **Pending asset optimization**
-   - Need to finalize hero and inline asset mapping. Placeholder hero set to `/public/assets/img/hero/guide-hero-{600|900|1400}.{avif|webp|jpg}` and audio TL;DR paths `/assets/audio/titanium-guide-tldr.(mp3|ogg)` require confirmed files. Tracked in `docs/OPERATIONS.md` open issues.
+   - Hero now points at `/public/assets/img/itstitanium-hero-pans-{800|1200|1600}.webp`; AVIF/JPG derivatives plus final inline art swaps still need to be produced, and richer audio voices remain under evaluation (tracked in `docs/OPERATIONS.md`).
 
 4. **ChatOps `/report` idea**
    - Placeholder command noted in `docs/OPERATIONS.md`; implementation still outstanding.
@@ -72,20 +85,20 @@ It tracks setup, troubleshooting, and next steps for the ChatOps + site automati
 
 ## 🚀 Next Steps
 
-1. **Automate ChatOps report publishing**
-   - Evaluate adding a `/report` workflow that runs `npm run report` and comments the output.
+1. **Confirm hero image filenames**
+   - Audit `/public/assets/img/` for the final hero renders, then update `<picture>` sources (including AVIF/JPG fallbacks) to match the delivered filenames.
 
-2. **Asset optimization follow-up**
-   - Finalize the pending image mapping/renaming work so hero assets match the new naming scheme.
+2. **Expand product schema coverage**
+   - Add additional verifiable entries such as the T-fal Ultimate Hard Anodized line, keeping claims limited to documentation we can cite.
 
-3. **Document deployment path**
-   - Capture Cloudflare Pages deploy procedures (prereqs, secrets, branch naming) so they are reproducible.
+3. **Evaluate richer narration**
+   - Prototype Piper TTS (or comparable) in the audio workflow so the TL;DR sounds more natural than the espeak baseline.
 
-4. **Quarterly content review**
-   - Schedule reminders to refresh `data/faq-bank.json` and `docs/disclosure.txt` against the editorial calendar.
+4. **Roll improvements to other pillars**
+   - Bring the same FTC placement, audio, share buttons, TOC, and structured data coverage to pages like `/titanium-vs-ceramic/`.
 
-5. **Swap in final media for the pillar**
-   - Replace placeholder hero assets and audio files once design delivers the approved renders and narration exports; rerun `npm run align` afterward to confirm no regressions.
+5. **Capture transcripts as assets**
+   - Store narration text as `.txt` companions in `/public/assets/audio/` to simplify edits without touching the workflow.
 
 ---
 

--- a/docs/pillars.md
+++ b/docs/pillars.md
@@ -1,0 +1,3 @@
+# Pillar Updates
+
+- 2025-09-29 — Titanium Cookware Guide pillar refreshed with new FTC disclosure placement, hero media, TL;DR audio, enhanced TOC, structured data, and supporting sections aligned to the 2025 checklist.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,3 @@
+# Workflow Updates
+
+- 2025-09-29 — Added `.github/workflows/make-audio.yml` (CI-based TL;DR narration) using espeak + ffmpeg to generate WAV → MP3/OGG, normalize levels, and auto-commit outputs under `public/assets/audio/`.


### PR DESCRIPTION
## Summary
- add a 2025-09-29 changelog entry capturing the titanium cookware guide rebuild, audio workflow launch, and checklist alignment
- refresh PROGRESS.md with the new accomplishments, checklist tag statuses, and revised next steps from the latest work session
- document the refreshed pillar and new audio CI workflow in docs/pillars.md and docs/workflows.md

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad4afb080832991e586ee2ec99681