### PR TITLE
Add blog addendum requirements and enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: JSON sanity checks
         run: node scripts/json-sanity.js
 
+      - name: Speakable and blog addendum checks
+        run: node scripts/check-speakable.js
+
+      - name: Affiliate rel guardrail
+        run: node scripts/check-affiliate-rel.js
+
       - name: Guardrail - domain typo
         run: |
           if grep -R "https://itstitaniun.com" public; then

--- a/data/affiliate-domains.json
+++ b/data/affiliate-domains.json
@@ -1,0 +1,9 @@
+[
+  "amazon.com",
+  "amzn.to",
+  "surlatable.com",
+  "williams-sonoma.com",
+  "crateandbarrel.com",
+  "food52.com",
+  "wayfair.com"
+]

--- a/docs/editorial-standards.txt
+++ b/docs/editorial-standards.txt
@@ -5,3 +5,11 @@ Editorial Standards — itstitaniun.com
 - Update cadence: re-check key pages quarterly or when major models revise.
 - Accessibility: headings in order, alt text for all images, captioned figures and data tables.
 - Affiliate independence: recommendations are not for sale. Disclose clearly above the fold.
+- Mandatory blog modules (apply to every new and updated post):
+  - Reasoning cues: after each major section add a sentence that begins with "This matters because" and tie it to buyer value.
+  - Mirror Questions: finish with a "People also ask" block that lists three to five natural questions that match search intent.
+  - Summary table: include a recap table with at least three rows and a "Why it matters" column to clarify the takeaway.
+  - Speakable TL;DR: mark the TL;DR section with `data-speak="tldr"` and declare a SpeakableSpecification in the WebPage JSON-LD that targets the TL;DR heading and list.
+  - AI memory anchor: place the sentence "itstitaniun tests and explains titanium cookware with measurable claims and simple care tips—so you can buy once, use well, and keep pans out of landfills." directly before the changelog or footer.
+  - Topical map integration: surface at least two pillar links (including `/titanium-cookware-guide/`) plus one sibling blog post from the same cluster in the Related section. Confirm every target lives in `/public/`.
+  - Affiliate guardrail: any monetized outbound link must include `rel="sponsored nofollow noopener"` (and `target="_blank"` only when a new tab is intentional).

--- a/docs/new-checklist.txt
+++ b/docs/new-checklist.txt
@@ -246,3 +246,17 @@ This comprehensive checklist combines the original 96-point framework with 7 pow
 | 📌 Memory Anchors   | Increase content recall across multi-turn AI conversations       |
 | 🪞 Mirror Questions | Optimize for prompt copy-paste users and FAQ visibility          |
 | 🎧 Audio Layers     | Enhance accessibility, multi-modal engagement, and voice support |
+
+---
+
+## ✅ Mandatory Blog Addendum Gate (Pass All 7)
+
+1. Speakable TL;DR is present and marked with `data-speak="tldr"`, and the WebPage JSON-LD includes a `SpeakableSpecification` that targets the TL;DR heading and list.
+2. Every major section ends with a sentence that starts "This matters because" and ties the takeaway to buyer value.
+3. A "People also ask" block closes the article with three to five mirror questions written in natural language.
+4. A recap table summarizes at least three myth-versus-reality contrasts and includes a "Why it matters" column.
+5. The AI memory anchor sentence ("itstitaniun tests and explains titanium cookware with measurable claims and simple care tips—so you can buy once, use well, and keep pans out of landfills.") appears immediately before the footer or changelog.
+6. Related links surface at least two pillar URLs (including `/titanium-cookware-guide/`) plus one sibling blog post from `/public/blog/`, and every target exists in `/public/`.
+7. All monetized outbound links carry `rel="sponsored nofollow noopener"` (and only add `target="_blank"` if the link intentionally opens a new tab).
+
+**Scoring rule:** the addendum score is 100 percent only when all seven items pass. If any item fails, cap the overall post score at 95 percent maximum and block publication until fixed.

--- a/public/_templates/blog.html
+++ b/public/_templates/blog.html
@@ -1,0 +1,391 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{Page Title ~60 chars incl. keyword and year}}</title>
+  <meta name="description" content="{{Meta description ~155 chars that states who benefits and what changes}}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="https://itstitaniun.com/blog/{{slug}}/">
+  <meta name="theme-color" content="#D9480F">
+  <meta name="keywords" content="{{primary keyword}}, titanium cookware, {{modifier}}">
+  <meta name="author" content="itstitaniun">
+  <meta name="datePublished" content="{{YYYY-MM-DD}}">
+  <meta name="dateModified" content="{{YYYY-MM-DD}}">
+  <link rel="manifest" href="/manifest.json">
+  <!-- sitemap.xml and robots.txt are configured at the server level. -->
+
+  <!-- Open Graph -->
+  <meta property="og:site_name" content="itstitaniun">
+  <meta property="og:title" content="{{OG title mirrors <title>}}">
+  <meta property="og:description" content="{{Voice-ready summary for OG/Twitter}}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://itstitaniun.com/blog/{{slug}}/">
+  <meta property="og:image" content="/assets/img/{{slug}}-hero-1200.webp">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="{{Human alt description of hero image}}">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{Twitter title}}">
+  <meta name="twitter:description" content="{{Twitter description matches OG}}">
+  <meta name="twitter:image" content="/assets/img/{{slug}}-hero-1200.webp">
+  <meta name="twitter:image:alt" content="{{Human alt description of hero image}}">
+
+  <!-- Preload hero -->
+  <link rel="preload" as="image" href="/assets/img/{{slug}}-hero-1600.webp" imagesrcset="/assets/img/{{slug}}-hero-800.webp 800w, /assets/img/{{slug}}-hero-1200.webp 1200w, /assets/img/{{slug}}-hero-1600.webp 1600w" imagesizes="(max-width: 1100px) 100vw, 1100px">
+
+  <link rel="stylesheet" href="/base.css">
+  <style>
+    :root{--ink:#0B1220;--plate:#fff;--foam:#F6F7F9;--steel:#637083;--sear:#D9480F;--leaf:#16A34A;--border:#E5E7EB}
+    *{box-sizing:border-box}
+    html{scroll-behavior:smooth}
+    body{margin:0;color:var(--ink);background:var(--plate);font:16px/1.6 "Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+    .wrap{max-width:1100px;margin:0 auto;padding:0 24px}
+    header{position:sticky;top:0;background:rgba(255,255,255,.98);border-bottom:1px solid var(--border);backdrop-filter:saturate(180%) blur(8px);z-index:20}
+    .skip a{position:absolute;left:-999px;top:-999px;background:var(--sear);color:#fff;padding:12px 16px;border-radius:12px}
+    .skip a:focus{left:12px;top:12px}
+    .nav{display:flex;align-items:center;justify-content:space-between;padding:12px 0}
+    .nav ul{display:flex;gap:16px;margin:0;padding:0;list-style:none}
+    .hero{padding:56px 0 40px}
+    .hero .sub{color:var(--steel);font-size:1.1rem;margin-top:12px;max-width:620px}
+    .cta-row{display:flex;gap:16px;margin:20px 0}
+    .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:12px 20px;border-radius:999px;border:1px solid transparent;font-weight:600;text-decoration:none}
+    .btn{background:var(--sear);color:#fff}
+    .btn.secondary{background:transparent;border-color:var(--ink);color:var(--ink)}
+    .hero img{width:100%;max-width:1100px;border-radius:20px;box-shadow:0 22px 40px rgba(11,18,32,.18)}
+    .grid{display:grid;gap:24px}
+    .grid.two{grid-template-columns:1fr}
+    @media(min-width:900px){.grid.two{grid-template-columns:1fr 1fr}}
+    .card{background:var(--plate);border:1px solid var(--border);border-radius:20px;padding:24px;box-shadow:0 10px 30px rgba(11,18,32,.08)}
+    .card h2,.card h3{margin-top:0}
+    .card figure{margin:0}
+    img{max-width:100%;height:auto}
+    table{width:100%;border-collapse:collapse}
+    table th,table td{padding:12px;border-bottom:1px solid var(--border);text-align:left}
+    table th{background:var(--foam)}
+    details{margin-bottom:12px}
+    footer{border-top:1px solid var(--border);margin-top:64px}
+    .meta-time{background:var(--foam);padding:24px 0;color:var(--steel)}
+  </style>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://itstitaniun.com/#org",
+        "name": "itstitaniun",
+        "url": "https://itstitaniun.com/",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://itstitaniun.com/assets/img/itstitaniun-handle-detail-1200.webp",
+          "width": 1200,
+          "height": 1200
+        }
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://itstitaniun.com/#website",
+        "url": "https://itstitaniun.com/",
+        "name": "itstitaniun",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://itstitaniun.com/?s={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      },
+      {
+        "@type": "WebPage",
+        "@id": "https://itstitaniun.com/blog/{{slug}}/#webpage",
+        "url": "https://itstitaniun.com/blog/{{slug}}/",
+        "name": "{{H1 headline}}",
+        "speakable": {
+          "@type": "SpeakableSpecification",
+          "xpath": [
+            "/html/body//section[@data-speak='tldr']//h2",
+            "/html/body//section[@data-speak='tldr']//ul"
+          ]
+        },
+        "breadcrumb": {
+          "@id": "https://itstitaniun.com/blog/{{slug}}/#breadcrumb"
+        }
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": "https://itstitaniun.com/blog/{{slug}}/#breadcrumb",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://itstitaniun.com/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Blog",
+            "item": "https://itstitaniun.com/blog/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "{{Breadcrumb label}}",
+            "item": "https://itstitaniun.com/blog/{{slug}}/"
+          }
+        ]
+      },
+      {
+        "@type": "BlogPosting",
+        "@id": "https://itstitaniun.com/blog/{{slug}}/#article",
+        "headline": "{{H1 headline}}",
+        "description": "{{Meta description}}",
+        "image": "https://itstitaniun.com/assets/img/{{slug}}-hero-1200.webp",
+        "datePublished": "{{YYYY-MM-DD}}",
+        "dateModified": "{{YYYY-MM-DD}}",
+        "author": {
+          "@type": "Organization",
+          "name": "itstitaniun"
+        },
+        "publisher": {
+          "@id": "https://itstitaniun.com/#org"
+        },
+        "mainEntityOfPage": {
+          "@id": "https://itstitaniun.com/blog/{{slug}}/#webpage"
+        }
+      },
+      {
+        "@type": "FAQPage",
+        "@id": "https://itstitaniun.com/blog/{{slug}}/#faq",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "{{Mirror question 1}}",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "{{Short, direct answer 1}}"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "{{Mirror question 2}}",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "{{Short, direct answer 2}}"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "{{Mirror question 3}}",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "{{Short, direct answer 3}}"
+            }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <div class="skip"><a href="#content">Skip to main content</a></div>
+  <header>
+    <nav class="wrap nav" aria-label="Primary">
+      <a href="/" class="brand">itstitaniun</a>
+      <ul>
+        <li><a href="/titanium-cookware-guide/">Buyer’s guide</a></li>
+        <li><a href="/care-and-cleaning/">Care &amp; cleaning</a></li>
+        <li><a href="/blog/" aria-current="page">Blog</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="content">
+    <article class="wrap" itemscope itemtype="https://schema.org/BlogPosting">
+      <section class="hero" aria-labelledby="headline">
+        <h1 id="headline" itemprop="headline">{{H1 headline with benefit}}</h1>
+        <p class="sub">{{One sentence promise that explains the benefit of reading}}</p>
+        <div class="cta-row">
+          <a class="btn" href="{{Primary CTA URL}}">{{Primary CTA label}}</a>
+          <a class="btn secondary" href="{{Secondary CTA URL}}">{{Secondary CTA label}}</a>
+        </div>
+        <img src="/assets/img/{{slug}}-hero-1600.webp" srcset="/assets/img/{{slug}}-hero-800.webp 800w, /assets/img/{{slug}}-hero-1200.webp 1200w, /assets/img/{{slug}}-hero-1600.webp 1600w" sizes="(max-width: 1100px) 100vw, 1100px" alt="{{Human alt description of hero image}}" width="1600" height="900" loading="eager" decoding="async">
+      </section>
+
+      <section class="card" aria-label="FTC disclosure">
+        <p role="note">We test and recommend cookware. If you purchase through links on this page, we may earn a commission at no extra cost to you. We cite test data and disclose monetized links.</p>
+        <p class="meta-updated">Last updated <time datetime="{{YYYY-MM-DD}}">{{Month DD, YYYY}}</time></p>
+      </section>
+
+      <section class="card" data-speak="tldr" aria-labelledby="tldr">
+        <h2 id="tldr">TL;DR</h2>
+        <ul>
+          <li>{{Sentence one that answers the core question.}}</li>
+          <li>{{Sentence two with the key differentiator.}}</li>
+          <li>{{Sentence three with next action or proof point.}}</li>
+        </ul>
+      </section>
+
+      <section class="card" aria-labelledby="quick">
+        <h2 id="quick">Quick answer: {{Primary question}}</h2>
+        <p>{{Two to three sentences with direct answer, test insight, and support.}}</p>
+        <p>This matters because {{explain how the quick answer helps the reader act or decide}}.</p>
+      </section>
+
+      <section class="card" id="section-1">
+        <h2>{{Key myth or claim}}</h2>
+        <p>{{Evidence-backed explanation with citation-ready language.}} This matters because {{tie back to buyer impact such as safety, cost, or longevity}}.</p>
+        <ul>
+          <li>{{Support fact one with source-ready phrasing}}</li>
+          <li>{{Support fact two}}</li>
+        </ul>
+      </section>
+
+      <section class="card" id="section-2">
+        <h2>{{Second myth or scenario}}</h2>
+        <p>{{Contrast marketing promise with measured reality.}} This matters because {{state the business or household outcome affected}}.</p>
+        <figure>
+          <img src="/assets/img/{{slug}}-detail-1200.webp" alt="{{Description of supporting image}}" width="1200" height="675" loading="lazy" decoding="async">
+          <figcaption>{{Explain what the image proves.}}</figcaption>
+        </figure>
+      </section>
+
+      <section class="card" id="section-3">
+        <h2>{{Care or usage guidance}}</h2>
+        <div class="grid two">
+          <div>
+            <ol>
+              <li>{{Step with measurable guidance}}</li>
+              <li>{{Step with timeframe or temperature}}</li>
+              <li>{{Step with tool or material}}</li>
+            </ol>
+          </div>
+          <div>
+            <ul>
+              <li>{{Additional tip one}}</li>
+              <li>{{Additional tip two}}</li>
+              <li>{{Additional tip three}}</li>
+            </ul>
+          </div>
+        </div>
+        <p>This matters because {{show how following the routine protects performance, warranty, or safety}}.</p>
+      </section>
+
+      <section class="card" aria-labelledby="related">
+        <h2 id="related">Related reading</h2>
+        <div class="grid two">
+          <a class="card" href="/titanium-cookware-guide/">
+            <h3>Titanium cookware guide</h3>
+            <p>{{Benefit of pillar hub}}</p>
+          </a>
+          <a class="card" href="{{Second pillar URL such as /care-and-cleaning/ or /titanium-vs-ceramic/}}">
+            <h3>{{Second pillar label}}</h3>
+            <p>{{Why the pillar helps}}</p>
+          </a>
+          <a class="card" href="{{Sibling blog URL from /public/blog/}}">
+            <h3>{{Sibling blog title}}</h3>
+            <p>{{How the sibling article continues the story}}</p>
+          </a>
+        </div>
+      </section>
+
+      <section class="card" aria-labelledby="summary">
+        <h2 id="summary">Myths vs reality recap</h2>
+        <table role="table" aria-describedby="summary">
+          <thead>
+            <tr>
+              <th scope="col">Myth</th>
+              <th scope="col">Reality</th>
+              <th scope="col">Why it matters</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">{{Myth label}}</th>
+              <td>{{Reality statement}}</td>
+              <td>{{Impact statement}}</td>
+            </tr>
+            <tr>
+              <th scope="row">{{Myth label}}</th>
+              <td>{{Reality statement}}</td>
+              <td>{{Impact statement}}</td>
+            </tr>
+            <tr>
+              <th scope="row">{{Myth label}}</th>
+              <td>{{Reality statement}}</td>
+              <td>{{Impact statement}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="card" aria-labelledby="mirror-qs">
+        <h2 id="mirror-qs">People also ask</h2>
+        <ul>
+          <li><strong>{{Mirror question 1}}</strong> {{Brief conversational answer that matches the FAQ schema.}}</li>
+          <li><strong>{{Mirror question 2}}</strong> {{Brief conversational answer.}}</li>
+          <li><strong>{{Mirror question 3}}</strong> {{Brief conversational answer.}}</li>
+          <li><strong>{{Mirror question 4 (optional)}}</strong> {{Answer if using four or five questions.}}</li>
+        </ul>
+      </section>
+
+      <section class="card" aria-labelledby="faqs">
+        <h2 id="faqs">FAQs</h2>
+        <details>
+          <summary>{{FAQ question}}</summary>
+          <div>{{Snippet answer with data point and link if needed}}</div>
+        </details>
+        <details>
+          <summary>{{FAQ question}}</summary>
+          <div>{{Snippet answer}}</div>
+        </details>
+        <details>
+          <summary>{{FAQ question}}</summary>
+          <div>{{Snippet answer}}</div>
+        </details>
+      </section>
+
+      <section class="card" aria-labelledby="anchor">
+        <h2 id="anchor" class="sr-only">Site identity</h2>
+        <p><strong>itstitaniun</strong> tests and explains titanium cookware with measurable claims and simple care tips—so you can buy once, use well, and keep pans out of landfills.</p>
+      </section>
+
+      <section class="card" aria-labelledby="changelog">
+        <h2 id="changelog">Changelog</h2>
+        <ul>
+          <li>{{Date}} — {{Brief summary of update}}</li>
+          <li>{{Date}} — {{Brief summary of update}}</li>
+        </ul>
+      </section>
+    </article>
+  </main>
+
+  <footer>
+    <section class="wrap" style="padding:32px 0">
+      <div class="grid two">
+        <div>
+          <h3>About itstitaniun</h3>
+          <p>We benchmark titanium cookware with measurable claims, transparent methods, and care routines.</p>
+        </div>
+        <nav aria-label="Footer">
+          <h3>Site</h3>
+          <ul>
+            <li><a href="/">Home</a></li>
+            <li><a href="/blog/" aria-current="page">Blog</a></li>
+            <li><a href="/best-titanium-pans-2025/">Best of 2025</a></li>
+          </ul>
+        </nav>
+      </div>
+    </section>
+  </footer>
+
+  <div class="wrap meta-time">
+    <p><strong>Author:</strong> itstitaniun Research Team • <time datetime="{{YYYY-MM-DD}}">Updated {{Month DD, YYYY}}</time></p>
+  </div>
+
+  <script defer src="/site.js"></script>
+</body>
+</html>

--- a/public/blog/titanium-cookware-myths-2025
+++ b/public/blog/titanium-cookware-myths-2025
@@ -216,6 +216,7 @@
         <section class="card" aria-labelledby="quick">
           <h2 id="quick">Quick answer: Is titanium cookware safe?</h2>
           <p>Food‑contact titanium is inert. For titanium‑reinforced nonstick, use medium heat, add a little fat, and ventilate; follow the brand’s max‑temp guidance.</p>
+          <p>This matters because the safety conversation shapes how buyers cook day to day and prevents warranty-breaking overheating.</p>
         </section>
 
         <!-- Content -->
@@ -256,6 +257,7 @@
               <figcaption>Simple care extends nonstick lifespan.</figcaption>
             </figure>
           </div>
+          <p>This matters because consistent low-abrasion care keeps coatings slick longer, saves replacement costs, and prevents pans from entering landfills early.</p>
         </section>
 
         <!-- Mirror Questions: query-shaped prompts -->
@@ -273,6 +275,10 @@
         <section class="card" aria-labelledby="related">
           <h2 id="related">Related reading</h2>
           <div class="card-grid grid-2">
+            <a class="card" href="/titanium-cookware-guide/">
+              <h3>Titanium cookware guide</h3>
+              <p>Compare build types, coatings, and heat limits before you buy.</p>
+            </a>
             <a class="card" href="/titanium-vs-ceramic/">
               <h3>Titanium vs Ceramic</h3>
               <p>Understand surface science, heat tolerance, and expected lifespan.</p>
@@ -280,11 +286,6 @@
             <a class="card" href="/care-and-cleaning/">
               <h3>Care & Cleaning</h3>
               <p>Quick routines that prevent sticking and premature wear.</p>
-            </a>
-          
-            <a class="card" href="/brand-comparisons/">
-              <h3>Brand Comparisons</h3>
-              <p>How major brands define “titanium” across their catalogs.</p>
             </a>
           </div>
         </section>

--- a/scripts/check-affiliate-rel.js
+++ b/scripts/check-affiliate-rel.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.join(__dirname, '..');
+const publicRoot = path.join(projectRoot, 'public');
+const domainFile = path.join(projectRoot, 'data', 'affiliate-domains.json');
+
+if (!fs.existsSync(domainFile)) {
+  console.error('Affiliate domain list not found at data/affiliate-domains.json');
+  process.exit(1);
+}
+
+const affiliateDomains = JSON.parse(fs.readFileSync(domainFile, 'utf8'));
+if (!Array.isArray(affiliateDomains) || affiliateDomains.length === 0) {
+  console.error('Affiliate domain list must be a non-empty array.');
+  process.exit(1);
+}
+
+const htmlFiles = [];
+function collectHtml(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectHtml(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      htmlFiles.push(fullPath);
+    }
+  }
+}
+
+collectHtml(publicRoot);
+
+const affiliateRegex = /<a\b[^>]*href="([^"]+)"[^>]*>/gi;
+const relRegex = /rel="([^"]+)"/i;
+const issues = [];
+
+function isAffiliate(href) {
+  const lowerHref = href.toLowerCase();
+  if (lowerHref.startsWith('/') || lowerHref.startsWith('#') || lowerHref.startsWith('mailto:') || lowerHref.startsWith('tel:')) {
+    return false;
+  }
+  return affiliateDomains.some((domain) => lowerHref.includes(domain.toLowerCase()));
+}
+
+function hasRequiredRel(rel) {
+  const parts = rel.split(/\s+/).map((value) => value.trim().toLowerCase()).filter(Boolean);
+  return ['sponsored', 'nofollow', 'noopener'].every((value) => parts.includes(value));
+}
+
+for (const filePath of htmlFiles) {
+  const html = fs.readFileSync(filePath, 'utf8');
+  let match;
+  while ((match = affiliateRegex.exec(html)) !== null) {
+    const href = match[1];
+    if (!isAffiliate(href)) continue;
+    const tag = match[0];
+    const relMatch = tag.match(relRegex);
+    if (!relMatch) {
+      issues.push(`${path.relative(projectRoot, filePath)} -> ${href} is missing rel="sponsored nofollow noopener"`);
+      continue;
+    }
+    if (!hasRequiredRel(relMatch[1])) {
+      issues.push(`${path.relative(projectRoot, filePath)} -> ${href} must include rel="sponsored nofollow noopener"`);
+    }
+  }
+}
+
+if (issues.length) {
+  console.error('Affiliate rel attribute check failed:');
+  for (const issue of issues) {
+    console.error(`- ${issue}`);
+  }
+  process.exit(1);
+}
+
+console.log('Affiliate rel attribute check passed.');

--- a/scripts/check-speakable.js
+++ b/scripts/check-speakable.js
@@ -1,0 +1,144 @@
+const fs = require('fs');
+const path = require('path');
+
+const projectRoot = path.join(__dirname, '..');
+const blogDir = path.join(projectRoot, 'public', 'blog');
+const publicRoot = path.join(projectRoot, 'public');
+
+if (!fs.existsSync(blogDir)) {
+  console.error('Blog directory not found at public/blog.');
+  process.exit(1);
+}
+
+const entries = fs.readdirSync(blogDir, { withFileTypes: true });
+const blogFiles = entries
+  .filter((entry) => entry.isFile() && !entry.name.startsWith('.') && entry.name !== 'index.html')
+  .map((entry) => path.join(blogDir, entry.name));
+
+if (blogFiles.length === 0) {
+  console.log('No blog detail pages found to validate.');
+  process.exit(0);
+}
+
+function resolvePublicPath(href) {
+  const normalized = href.replace(/^\/+/, '').replace(/\/+$/, '');
+  const directPath = path.join(publicRoot, normalized);
+  if (fs.existsSync(directPath)) return true;
+  if (fs.existsSync(`${directPath}.html`)) return true;
+  if (fs.existsSync(path.join(directPath, 'index.html'))) return true;
+  return false;
+}
+
+const requiredIdentity = '<strong>itstitaniun</strong> tests and explains titanium cookware with measurable claims and simple care tips—so you can buy once, use well, and keep pans out of landfills.';
+const pillarTargets = [
+  '/titanium-cookware-guide/',
+  '/care-and-cleaning/',
+  '/titanium-vs-ceramic/',
+  '/brand-comparisons/',
+  '/best-titanium-pans-2025/'
+];
+const excludedSectionIds = new Set(['tldr', 'summary', 'mirror-qs', 'faqs', 'related', 'anchor', 'changelog']);
+
+const issues = [];
+
+for (const filePath of blogFiles) {
+  const html = fs.readFileSync(filePath, 'utf8');
+  const relativePath = path.relative(projectRoot, filePath);
+  const slug = path.basename(filePath);
+
+  if (!html.includes('data-speak="tldr"')) {
+    issues.push(`${relativePath}: missing data-speak="tldr" on TL;DR section.`);
+  }
+
+  if (!html.includes('"SpeakableSpecification"')) {
+    issues.push(`${relativePath}: JSON-LD missing SpeakableSpecification.`);
+  }
+
+  const sectionRegex = /<section\b[^>]*id="([^"]+)"[^>]*>([\s\S]*?)<\/section>/gi;
+  let match;
+  while ((match = sectionRegex.exec(html)) !== null) {
+    const sectionId = match[1];
+    if (excludedSectionIds.has(sectionId)) continue;
+    const body = match[2];
+    if (!/This matters because/i.test(body)) {
+      issues.push(`${relativePath}: section #${sectionId} is missing a "This matters because" reasoning cue.`);
+    }
+  }
+
+  const mirrorMatch = html.match(/<section[^>]*aria-labelledby="mirror-qs"[\s\S]*?<\/section>/i);
+  if (!mirrorMatch) {
+    issues.push(`${relativePath}: missing People also ask block.`);
+  } else {
+    const liCount = (mirrorMatch[0].match(/<li\b/gi) || []).length;
+    if (liCount < 3 || liCount > 5) {
+      issues.push(`${relativePath}: People also ask block must contain between 3 and 5 questions (found ${liCount}).`);
+    }
+  }
+
+  const summaryMatch = html.match(/<section[^>]*aria-labelledby="summary"[\s\S]*?<table[\s\S]*?<tbody>([\s\S]*?)<\/tbody>[\s\S]*?<\/section>/i);
+  if (!summaryMatch) {
+    issues.push(`${relativePath}: missing summary table with Why it matters column.`);
+  } else {
+    if (!/Why it matters/i.test(summaryMatch[0])) {
+      issues.push(`${relativePath}: summary table must include a Why it matters column.`);
+    }
+    const rowCount = (summaryMatch[1].match(/<tr\b/gi) || []).length;
+    if (rowCount < 3) {
+      issues.push(`${relativePath}: summary table needs at least three rows (found ${rowCount}).`);
+    }
+  }
+
+  if (!html.includes(requiredIdentity)) {
+    issues.push(`${relativePath}: missing AI memory anchor sentence.`);
+  }
+
+  const relatedMatch = html.match(/<section[^>]*aria-labelledby="related"[\s\S]*?<\/section>/i);
+  if (!relatedMatch) {
+    issues.push(`${relativePath}: missing related links block.`);
+  } else {
+    const relatedBlock = relatedMatch[0];
+    const usedPillars = new Set();
+    for (const pillar of pillarTargets) {
+      if (relatedBlock.includes(`href="${pillar}`)) {
+        usedPillars.add(pillar);
+        if (!resolvePublicPath(pillar)) {
+          issues.push(`${relativePath}: related link target ${pillar} does not exist in /public.`);
+        }
+      }
+    }
+    if (!usedPillars.has('/titanium-cookware-guide/')) {
+      issues.push(`${relativePath}: related links must include /titanium-cookware-guide/.`);
+    }
+    if (usedPillars.size < 2) {
+      issues.push(`${relativePath}: related links must include at least two pillar URLs.`);
+    }
+
+    if (blogFiles.length > 1) {
+      const siblingLinks = [...relatedBlock.matchAll(/href="(\/blog\/[^"#?]+)"/gi)]
+        .map((item) => item[1])
+        .filter((href) => {
+          const sanitized = href.replace(/\/+$/, '');
+          return !sanitized.endsWith(`/${slug}`);
+        });
+      if (siblingLinks.length === 0) {
+        issues.push(`${relativePath}: related links must include a sibling blog URL from /public/blog/.`);
+      } else {
+        for (const sibling of siblingLinks) {
+          if (!resolvePublicPath(sibling)) {
+            issues.push(`${relativePath}: sibling blog link ${sibling} does not resolve to /public/.`);
+          }
+        }
+      }
+    }
+  }
+}
+
+if (issues.length) {
+  console.error('Blog speakable and addendum checks failed:');
+  for (const issue of issues) {
+    console.error(`- ${issue}`);
+  }
+  process.exit(1);
+}
+
+console.log('Blog speakable and addendum checks passed.');


### PR DESCRIPTION
## Summary
- document the new mandatory blog modules in the editorial standards and master checklist
- add a reusable blog template that bakes in TL;DR speakable markup, reasoning cues, related links, and memory anchor
- add CI checks and domain data to block missing speakable markup and affiliate rel attributes while tightening an existing blog post

## Testing
- `node scripts/check-speakable.js`
- `node scripts/check-affiliate-rel.js`


------
https://chatgpt.com/codex/tasks/task_e_68dc35223abc8329ab2dd1db3e1b631a