### PR TITLE
Add missing blog posts to sitemap

### DIFF
--- a/public/blog/titanium-cutting-boards-guide.html
+++ b/public/blog/titanium-cutting-boards-guide.html
@@ -6,13 +6,13 @@
   <meta name="description" content="A brand-styled, organized guide to titanium cutting boards—what they are, who they’re for, benefits & trade-offs, care & cleaning, and comparisons to wood, plastic, and bamboo.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
-  <link rel="canonical" href="https://itstitanium.com/titanium-cutting-boards-guide.html">
+  <link rel="canonical" href="https://itstitaniun.com/blog/titanium-cutting-boards-guide.html">
   <meta name="theme-color" content="#0B1220">
 
   <!-- Open Graph -->
   <meta property="og:type" content="article">
   <meta property="og:site_name" content="itstitanium">
-  <meta property="og:url" content="https://itstitanium.com/titanium-cutting-boards-guide.html">
+  <meta property="og:url" content="https://itstitaniun.com/blog/titanium-cutting-boards-guide.html">
   <meta property="og:title" content="Titanium Cutting Boards Guide: Benefits, Care & Comparison">
   <meta property="og:description" content="Benefits & trade-offs, care & cleaning, and comparisons to wood, plastic, and bamboo.">
   <meta property="og:image" content="https://itstitanium.com/public/itstitaniun-hero-og-1200x630.webp">
@@ -95,7 +95,7 @@
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#breadcrumbs",
+        "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#breadcrumbs",
         "itemListElement": [
           { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://itstitanium.com/" },
           { "@type": "ListItem", "position": 2, "name": "Guides", "item": "https://itstitanium.com/titanium-cookware-guide/" },
@@ -104,29 +104,29 @@
       },
       {
         "@type": "WebPage",
-        "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#webpage",
-        "url": "https://itstitanium.com/titanium-cutting-boards-guide.html",
+        "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#webpage",
+        "url": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html",
         "name": "Titanium Cutting Boards Guide: Benefits, Care & Comparison",
         "isPartOf": { "@id": "https://itstitanium.com/#website" },
-        "breadcrumb": { "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#breadcrumbs" },
+        "breadcrumb": { "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#breadcrumbs" },
         "datePublished": "2025-10-03",
         "dateModified": "2025-10-03",
         "inLanguage": "en"
       },
       {
         "@type": "BlogPosting",
-        "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#article",
+        "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#article",
         "headline": "Titanium Cutting Boards Guide: Benefits, Care & Comparison",
         "description": "A practical guide to titanium cutting boards—benefits & trade-offs, care & cleaning, and how they compare to wood, plastic, and bamboo.",
         "author": { "@type": "Organization", "name": "itstitanium" },
         "publisher": { "@id": "https://itstitanium.com/#org" },
         "datePublished": "2025-10-03",
         "dateModified": "2025-10-03",
-        "mainEntityOfPage": { "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#webpage" }
+        "mainEntityOfPage": { "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#webpage" }
       },
       {
         "@type": "HowTo",
-        "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#howto-care",
+        "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#howto-care",
         "name": "How to care for a titanium cutting board",
         "step": [
           { "@type": "HowToStep", "position": 1, "name": "Rinse", "text": "After prep, rinse debris with warm water." },
@@ -137,7 +137,7 @@
       },
       {
         "@type": "FAQPage",
-        "@id": "https://itstitanium.com/titanium-cutting-boards-guide.html#faq",
+        "@id": "https://itstitaniun.com/blog/titanium-cutting-boards-guide.html#faq",
         "mainEntity": [
           {
             "@type": "Question",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -26,4 +26,12 @@
     <loc>https://itstitaniun.com/blog/titanium-cookware-myths-2025/</loc>
     <lastmod>2025-09-29</lastmod>
   </url>
+  <url>
+    <loc>https://itstitaniun.com/blog/titanium-cutting-boards-guide.html</loc>
+    <lastmod>2025-10-03</lastmod>
+  </url>
+  <url>
+    <loc>https://itstitaniun.com/blog/titanium-vs-ceramic-cookware</loc>
+    <lastmod>2025-10-02</lastmod>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add the two latest blog article URLs to the sitemap so the index script can discover them
- align the titanium cutting boards guide canonical and structured data URLs with the /blog/ path

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dff814f9e483298c36c727d8f71c3c