### PR TITLE
Update AWIN affiliate link

### DIFF
--- a/public/best-titanium-pans-2025/index.html
+++ b/public/best-titanium-pans-2025/index.html
@@ -301,7 +301,7 @@
             "@type": "ListItem",
             "position": 1,
             "name": "Taima Titanium Nutri Pan Pro 2.0",
-            "url": "https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Ftaima-titanium-nutri-pan-pro-2-0"
+            "url": "https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy"
           },
           {
             "@type": "ListItem",
@@ -423,7 +423,7 @@
         <h1>Best Titanium Pans for 2025</h1>
         <p class="sub">We spent 180 lab hours on heat maps, abrasion cycles, and real meal cooking to rank titanium reinforced skillets you can trust nightly.</p>
         <div class="cta-row">
-          <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Ftaima-titanium-nutri-pan-pro-2-0" rel="sponsored nofollow noopener">Get Taima Nutri Pan Pro 2.0</a>
+          <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener">Get Taima Nutri Pan Pro 2.0</a>
           <a class="btn btn-outline" href="/titanium-cookware-guide/">See how to choose</a>
         </div>
         <img src="/assets/img/itstitaniun-even-browning-1200.webp" alt="Titanium skillets shown with even browning pancakes" width="1200" height="800" loading="eager">
@@ -444,7 +444,7 @@
         <h2>Top ranked titanium reinforced skillets</h2>
         <p>Our picks lean on verified manufacturer specs, compatibility, and long-term ownership feedback instead of hype. We highlight construction, oven rating, and how each pan fits different kitchens.</p>
         <ul>
-          <li><strong>Taima Titanium Nutri Pan Pro 2.0 (Top pick):</strong> A 5-ply full-clad pan with a pure titanium cooking surface — no PFAS, PTFE, or PFOA. Oven- and flame-safe to 1112°F, induction-ready on all cooktops, dishwasher and metal-utensil safe, backed by a lifetime warranty, and sold individually in four sizes (9.5" to 12"). <a href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Ftaima-titanium-nutri-pan-pro-2-0" rel="sponsored nofollow noopener">See Taima Nutri Pan Pro 2.0</a>.</li>
+          <li><strong>Taima Titanium Nutri Pan Pro 2.0 (Top pick):</strong> A 5-ply full-clad pan with a pure titanium cooking surface — no PFAS, PTFE, or PFOA. Oven- and flame-safe to 1112°F, induction-ready on all cooktops, dishwasher and metal-utensil safe, backed by a lifetime warranty, and sold individually in four sizes (9.5" to 12"). <a href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener">See Taima Nutri Pan Pro 2.0</a>.</li>
 
           <li><strong>Guy Fieri's Flavortown Laser Titanium 2-piece fry pan set (8.5&quot; and 10&quot;):</strong> Hard-anodized aluminum base with a laser-etched titanium cooking surface that delivers nonstick-style release without a chemical coating. Made without PFAS, PTFE, and PFOA, safe for metal utensils, oven safe up to 700°F (500°F with lids), and rated dishwasher safe, though hand-washing is still recommended. Not induction compatible; best on gas, electric, or ceramic tops. <a href="https://amzn.to/3Yl0cNL" rel="sponsored nofollow noopener">See Flavortown Laser Titanium set</a>.</li>
 
@@ -482,7 +482,7 @@
                 <td>Yes; also metal-utensil safe</td>
                 <td>Lifetime warranty</td>
                 <td>
-                  <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Ftaima-titanium-nutri-pan-pro-2-0"
+                  <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy"
                      rel="sponsored nofollow noopener"
                      target="_blank">Get Taima Nutri Pan Pro 2.0</a>
                 </td>
@@ -590,7 +590,7 @@
         <h2>Next steps</h2>
         <p>Confirm your cooktop type, decide if you want a coating-free titanium surface or traditional nonstick, then match oven rating and warranty to how hard you are on your pans. Set price alerts on retailer sites before buying, and keep an eye on our titanium cookware guide as we add more tested models.</p>
         <div class="cta-row">
-          <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Ftaima-titanium-nutri-pan-pro-2-0" rel="sponsored nofollow noopener">Get Taima Nutri Pan Pro 2.0</a>
+          <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener">Get Taima Nutri Pan Pro 2.0</a>
           <a class="btn btn-outline" href="mailto:editors@itstitanium.com">Ask our test kitchen</a>
         </div>
       </section>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -247,6 +247,15 @@
     </div>
   </section>
 
+  <!-- Editor's cookware pick -->
+  <section class="wrap" id="editors-pick">
+    <div class="card">
+      <h2>Editor's cookware pick</h2>
+      <p>Shopping for a coating-free titanium pan? Taima bundles include multiple sizes of our current top pick.</p>
+      <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop Taima bundles</a>
+    </div>
+  </section>
+
   <!-- FAQ -->
   <section class="wrap faq" id="faq">
     <div class="card">

--- a/public/blog/titanium-cookware-myths-2025.html
+++ b/public/blog/titanium-cookware-myths-2025.html
@@ -953,7 +953,8 @@
           <div class="cta-card" role="complementary" aria-label="Call to action">
             <h2>Ready to find the right pan?</h2>
             <p>We tested the top titanium options so you don't have to. See our vetted picks with full specs.</p>
-            <a class="btn btn-primary" href="/best-titanium-pans-2025/">See the Best Titanium Pans 2025</a>
+            <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop Taima bundles</a>
+            <a class="btn btn-secondary" href="/best-titanium-pans-2025/">Compare all top picks</a>
           </div>
 
         </article>

--- a/public/blog/titanium-cutting-boards-guide.html
+++ b/public/blog/titanium-cutting-boards-guide.html
@@ -865,9 +865,9 @@
 
           <!-- Bottom CTA -->
           <div class="cta-card" role="complementary" aria-label="Call to action">
-            <h2>Ready to find the right pan?</h2>
-            <p>We tested the top titanium options so you don't have to. See our vetted picks with full specs.</p>
-            <a class="btn btn-primary" href="/best-titanium-pans-2025/">See the Best Titanium Pans 2025</a>
+            <h2>Ready to try a titanium cutting board?</h2>
+            <p>Taima's three-piece pure titanium set provides multiple sizes for prep, slicing, and serving.</p>
+            <a class="btn btn-primary" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Fpure-titanium-cutting-board-set-3-piece%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop the Taima cutting board set</a>
           </div>
 
         </article>

--- a/public/blog/titanium-vs-ceramic-cookware
+++ b/public/blog/titanium-vs-ceramic-cookware
@@ -243,7 +243,8 @@ a{color:#0ea5e9}
     <div class='card' style='text-align:center;padding:clamp(24px,4vw,40px)'>
       <h2 style='margin-bottom:8px'>Ready to pick the right pan?</h2>
       <p style='margin-bottom:20px;color:var(--steel)'>We tested the top titanium options so you don't have to. See our vetted picks.</p>
-      <a class='btn btn-primary' href='/best-titanium-pans-2025/'>See the Best Titanium Pans 2025 →</a>
+      <a class='btn btn-primary' href='https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy' rel='sponsored nofollow noopener' target='_blank'>Shop Taima bundles →</a>
+      <a class='btn' href='/best-titanium-pans-2025/'>Compare all top picks</a>
     </div>
   </section>
 </main>

--- a/public/brand-comparisons/index.html
+++ b/public/brand-comparisons/index.html
@@ -492,6 +492,7 @@
         <p>Match warranty coverage and heat targets with your budget, then confirm stock availability before sale season. Legacy URL /titanium-brand-guide now delivers a 308 redirect to this comparison.</p>
         <div class="cta-row">
           <a class="btn" href="/best-titanium-pans-2025/">Check best overall picks</a>
+          <a class="btn btn-outline" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop Taima bundles</a>
           <a class="btn btn-outline" href="mailto:editors@itstitanium.com">Request lab score PDF</a>
         </div>
       </section>

--- a/public/care-and-cleaning/index.html
+++ b/public/care-and-cleaning/index.html
@@ -489,6 +489,7 @@
         <p>Print this checklist, stock the right tools, and set quarterly reminders to inspect handles and bases. Legacy address /titanium-cleaning-guide now points here with a 308 redirect.</p>
         <div class="cta-row">
           <a class="btn" href="/best-titanium-pans-2025/">See pans worth protecting</a>
+          <a class="btn btn-outline" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop Taima bundles</a>
           <a class="btn btn-outline" href="mailto:editors@itstitanium.com">Share your care results</a>
         </div>
       </section>

--- a/public/index.html
+++ b/public/index.html
@@ -718,7 +718,7 @@
           <h3>Taima Nutri Pan Pro 2.0</h3>
           <p>5-ply titanium interior, oven-safe to 1112°F, lifetime warranty.</p>
           <a class="btn btn-primary"
-             href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fproducts%2Ftaima-titanium-nutri-pan-pro-2-0"
+             href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy"
              rel="sponsored nofollow noopener"
              target="_blank">Get Taima Nutri Pan Pro 2.0</a>
         </div>

--- a/public/titanium-cookware-guide/index.html
+++ b/public/titanium-cookware-guide/index.html
@@ -556,6 +556,7 @@
       <p>Shortlist pans using the spec table above, confirm warranty language on the product page, and run our care checklist after your first cook.</p>
       <div class="cta-row">
         <a class="btn btn-primary" href="/best-titanium-pans-2025/">Review top picks</a>
+        <a class="btn btn-outline" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop Taima bundles</a>
         <a class="btn btn-outline" href="/titanium-vs-ceramic/">Compare with ceramic</a>
       </div>
     </div>

--- a/public/titanium-vs-ceramic/index.html
+++ b/public/titanium-vs-ceramic/index.html
@@ -497,6 +497,7 @@
         <p>Match these data points with your cooking habits, then review our titanium picks or ceramic alternatives before buying. Legacy path /compare-titanium-ceramic now issues a 308 redirect here.</p>
         <div class="cta-row">
           <a class="btn" href="/best-titanium-pans-2025/">Compare titanium options</a>
+          <a class="btn btn-outline" href="https://www.awin1.com/cread.php?awinmid=112034&awinaffid=2671004&ued=https%3A%2F%2Ftaimatitanium.com%2Fcollections%2Fbundles%3Futm_source%3Dawin%26utm_id%3D2671004_%26utm_campaign%3Daffiliate%26awc%3D112034_1779996856_388446ebd5ca1f7ff09bde9cb52087c7%26tw_source%3Dgoogle%26tw_adid%3D793547065134%26tw_campaign%3D23201820691%26tw_kwdid%3Dkwd-2372479527826%26gclid%3DCjwKCAjwpefSBhBvEiwAzyEtZ1oCvj7YSlZoODWuiddK6FPE6l5CUtnm0gNWMzlI9deTXXw2uaUMRBoCTQkQAvD_BwE%26gad_source%3D1%26gad_campaignid%3D23201820691%26gbraid%3D0AAAABBSG7PgtkVch98sVUcY-pYihESVVy" rel="sponsored nofollow noopener" target="_blank">Shop Taima bundles</a>
           <a class="btn btn-outline" href="mailto:editors@itstitanium.com">Ask for ceramic suggestions</a>
         </div>
       </section>


### PR DESCRIPTION
## What changed

- Replaced the existing Taima cookware AWIN URL with the supplied Taima bundles campaign URL.
- Added one contextual Taima cookware CTA to each cookware-relevant page.
- Replaced the cutting-board article's unrelated pan CTA with the supplied three-piece Taima cutting-board AWIN URL.

## Placement strategy

- Buying guide and comparison pages: CTA within the existing next-steps action group.
- Blog index: compact editor's-pick section near related guides.
- Cookware blog articles: CTA in the existing bottom purchase-decision block while preserving internal comparison links.
- Cutting-board article: product-specific CTA for the Taima three-piece cutting-board set.

## Validation

- All 10 public pages now have a contextually relevant Taima affiliate placement.
- 14 total AWIN URL references: 13 sponsored clickable links plus 1 product structured-data URL.
- Every clickable AWIN link uses `rel="sponsored nofollow noopener"`.
- The previous cookware AWIN URL no longer appears in the affected pages.
- Compared with `main`: only the 10 intended public page files changed.